### PR TITLE
Fix: Average Productivity Across Worker Tiers

### DIFF
--- a/src/v1/composables/useCalculations.ts
+++ b/src/v1/composables/useCalculations.ts
@@ -1,5 +1,12 @@
 import { computed, type Ref } from 'vue'
-import type { BuildingInstance, GameData, Recipe, Calculations, IndustryType, WorkerTier } from '../types'
+import type {
+  BuildingInstance,
+  GameData,
+  Recipe,
+  Calculations,
+  IndustryType,
+  WorkerTier,
+} from '../types'
 import { TIME_CONSTANTS } from '../config/constants'
 import { WORKER_CONSUMPTION_BY_TIER } from '../data/workerConsumption'
 
@@ -22,7 +29,7 @@ export function useCalculations(
 
       const qty = building.quantity
       totalWorkers += buildingData.workers * qty
-      
+
       // Acumular workers por tier
       buildingData.workersByTier.forEach((count, index) => {
         if (index < 4 && totalWorkersByTier[index] !== undefined) {
@@ -44,33 +51,28 @@ export function useCalculations(
           recipeTime = recipe.time * (100 / recipeItem.planetModifier)
         }
 
-        // Determinar qué tier de worker tiene este edificio
-        // Un edificio usa el tier del primer worker que tenga
-        let workerTierIndex = 0
-        for (let i = 0; i < buildingData.workersByTier.length; i++) {
-          const tierCount = buildingData.workersByTier[i]
-          if (tierCount !== undefined && tierCount > 0) {
-            workerTierIndex = i
-            break
-          }
-        }
-        
-        // Usar la productividad específica de ese tier
-        const tierProductivity = productivityByTier.value[workerTierIndex]
-        if (tierProductivity === undefined) return
-        
+        // Average productivity across tiers present
+        const presentTierIndices = (buildingData.workersByTier ?? []).flatMap((count, index) =>
+          typeof count === 'number' && count > 0 ? [index] : [],
+        )
+
+        if (presentTierIndices.length === 0) return
+
+        const avgTierProductivity =
+          presentTierIndices
+            .map((index) => productivityByTier.value[index] ?? 100)
+            .reduce((acc, value) => acc + value, 0) / presentTierIndices.length
+
         // Apply technology as multiplier (not additive)
         const techLevel = technologyLevels.value[buildingData.industryType] || 0
         const techMultiplier = (100 + techLevel) / 100
-        
-        const productivityMultiplier = tierProductivity / 100
-        
+
         // Combined multiplier (multiplicative, not additive)
-        const combinedMultiplier = productivityMultiplier * techMultiplier
-        
+        const combinedMultiplier = (avgTierProductivity / 100) * techMultiplier
+
         // Apply to recipe time (higher multiplier = less time)
         recipeTime = recipeTime / combinedMultiplier
-        
+
         // Apply game speed
         recipeTime = recipeTime / gameSpeed.value
 
@@ -100,20 +102,20 @@ export function useCalculations(
     // Calcular consumo de workers por tier
     const workerConsumption: Record<string, number> = {}
     const tierNames: WorkerTier[] = ['worker', 'technician', 'engineer', 'scientist']
-    
+
     totalWorkersByTier.forEach((count, index) => {
       if (count > 0) {
         const tierName = tierNames[index]
         if (!tierName) return
-        
+
         const tierConsumption = WORKER_CONSUMPTION_BY_TIER[tierName]
         if (!tierConsumption) return
-        
+
         const workerGroups = count / 100
-        
+
         Object.entries(tierConsumption).forEach(([resource, amount]) => {
           if (typeof amount === 'number') {
-            workerConsumption[resource] = (workerConsumption[resource] || 0) + (amount * workerGroups)
+            workerConsumption[resource] = (workerConsumption[resource] || 0) + amount * workerGroups
           }
         })
       }


### PR DESCRIPTION
> LTDR: consumables boost mixed-worker buildings by averaging productivity across tiers

The old logic picked the first non-zero worker tier and used only that tier's productivity. Mixed setups (e.g. Workers + Technicians) didn’t benefit when consumables like coffee were enabled on the other tier. I now collect all tiers with >0 workers and take a simple (unweighted) average of their productivity. If a tier’s productivity is missing, I fall back to 100 to keep math stable.

https://github.com/user-attachments/assets/2a92c64c-9399-4388-8a47-78954e22a76c

Used Space Inc scenarios to test. `Quarry Complex` and `Electrons Factory` now show the expected productivity bump when coffee is on for any involved tier. Single-tier buildings are unchanged. Planet modifiers and tech are still applied as before.