### PR TITLE
Add configurable timeframe and adjust summary displays

### DIFF
--- a/src/v2/localisation/localisation.ts
+++ b/src/v2/localisation/localisation.ts
@@ -29,6 +29,7 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     requiresBuilding: 'Requires building',
     noRecipesConfigured: 'No recipes configured yet',
     dailySummary: 'Daily summary',
+    summaryForHours: 'Summary for {hours}h',
     sectionProduction: 'Production',
     sectionBuildings: 'Buildings',
     totalRevenue: 'Total revenue',
@@ -42,14 +43,18 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     materialBalance: 'Materials balance',
     material: 'Material',
     perDay: 'per day',
+    perHours: 'per {hours}h',
     unitPrice: 'Unit price',
     totalWorkerCosts: 'Total worker costs',
     workers: 'Workers',
     activeModules: 'Active modules',
     queueTimeShare: 'Queue time share',
     dailyRunsPerModule: 'Runs per module per day',
+    runsPerHours: 'Runs per module per {hours}h',
     outputPerDay: 'Output per day',
+    outputPerHours: 'Output per {hours}h',
     inputsPerDay: 'Inputs',
+    inputsPerHours: 'Inputs per {hours}h',
     cycleTime: 'Cycle time',
     baseCycleTime: 'Base cycle time',
     actualCycleTime: 'Effective cycle time',
@@ -118,6 +123,9 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     stockImportError: 'Import failed – please check the format.',
     stockCoverage: 'Stock coverage',
     lessThanHour: '<1h',
+    toBuy: 'To buy',
+    timeframeHoursLabel: 'Summary window (hours)',
+    timeframeHoursHint: 'Applies to all calculations (max 336h).',
   },
   de: {
     language: 'Sprache',
@@ -143,6 +151,7 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     requiresBuilding: 'Benötigt Gebäude',
     noRecipesConfigured: 'Noch keine Rezepte konfiguriert',
     dailySummary: 'Tägliche Übersicht',
+    summaryForHours: 'Übersicht für {hours}h',
     sectionProduction: 'Produktion',
     sectionBuildings: 'Gebäude',
     totalRevenue: 'Gesamterlös',
@@ -156,14 +165,18 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     materialBalance: 'Materialbilanz',
     material: 'Material',
     perDay: 'pro Tag',
+    perHours: 'pro {hours}h',
     unitPrice: 'Preis',
     totalWorkerCosts: 'Summe Verbrauchskosten',
     workers: 'Arbeiter',
     activeModules: 'Aktive Module',
     queueTimeShare: 'Zeitanteil der Queue',
     dailyRunsPerModule: 'Durchgänge pro Tag',
+    runsPerHours: 'Durchgänge pro Modul pro {hours}h',
     outputPerDay: 'Ausstoß pro Tag',
+    outputPerHours: 'Ausstoß pro {hours}h',
     inputsPerDay: 'Input',
+    inputsPerHours: 'Input pro {hours}h',
     cycleTime: 'Zykluszeit',
     baseCycleTime: 'Normale Zykluszeit',
     actualCycleTime: 'Reale Zykluszeit',
@@ -232,6 +245,9 @@ const messages: Record<LanguageCode, Record<string, string>> = {
     stockImportError: 'Import fehlgeschlagen – bitte Format prüfen.',
     stockCoverage: 'Reichweite Lager',
     lessThanHour: '<1h',
+    toBuy: 'Zukauf',
+    timeframeHoursLabel: 'Berechnungszeitraum (Stunden)',
+    timeframeHoursHint: 'Gilt für alle Berechnungen (max. 336h).',
   },
 }
 
@@ -245,8 +261,16 @@ function detectInitial(): LanguageCode {
   return (['en', 'de'].includes(browser) ? browser : 'en') as LanguageCode
 }
 
-export function translate(key: string): string {
-  return messages[currentLanguage.value]?.[key] ?? key
+export function translate(
+  key: string,
+  vars?: Record<string, string | number>,
+): string {
+  const template = messages[currentLanguage.value]?.[key] ?? key
+  if (!vars) return template
+  return template.replace(/\{(\w+)\}/g, (_, token: string) => {
+    const value = vars[token]
+    return value == null ? '' : String(value)
+  })
 }
 
 export function setLanguage(lang: LanguageCode): void {

--- a/src/v2/pages/player-config/PlayerConfigPanel.vue
+++ b/src/v2/pages/player-config/PlayerConfigPanel.vue
@@ -39,6 +39,28 @@ const startingBonus = computed(() => technologyState.value.startingBonus ?? 1)
 
 const query = ref('')
 
+const TIMEFRAME_STORAGE_KEY = 'gt:v2:timeframeHours'
+const DEFAULT_TIMEFRAME_HOURS = 24
+
+function sanitizeTimeframe(value: unknown): number {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  if (!Number.isFinite(numeric)) return DEFAULT_TIMEFRAME_HOURS
+  const clamped = Math.min(336, Math.max(1, Math.round(numeric)))
+  return clamped
+}
+
+function loadTimeframe(): number {
+  try {
+    const raw = localStorage.getItem(TIMEFRAME_STORAGE_KEY)
+    if (raw == null) return DEFAULT_TIMEFRAME_HOURS
+    return sanitizeTimeframe(Number(raw))
+  } catch {
+    return DEFAULT_TIMEFRAME_HOURS
+  }
+}
+
+const timeframeHours = ref(loadTimeframe())
+
 const suggestions = computed<Planet[]>(() => {
   const text = query.value.trim()
   if (text.length < 2) return []
@@ -126,6 +148,21 @@ function selectPlanet(planet: Planet) {
 function getPlanetById(id: number) {
   return props.gameData.planets.find((pl) => pl.id === id)
 }
+
+watch(
+  timeframeHours,
+  (value) => {
+    const sanitized = sanitizeTimeframe(value)
+    if (sanitized !== value) {
+      timeframeHours.value = sanitized
+      return
+    }
+    try {
+      localStorage.setItem(TIMEFRAME_STORAGE_KEY, String(sanitized))
+    } catch {}
+  },
+  { immediate: false },
+)
 </script>
 
 <template>
@@ -155,6 +192,22 @@ function getPlanetById(id: number) {
       <div v-if="priceError" class="text-amber-300">
         {{ translate('priceError') }}: {{ priceError }}
       </div>
+      <div class="flex items-center gap-2">
+        <label class="flex items-center gap-2">
+          <span>{{ translate('timeframeHoursLabel') }}</span>
+          <input
+            v-model.number="timeframeHours"
+            type="number"
+            min="1"
+            max="336"
+            step="1"
+            class="w-20 bg-slate-900 border border-slate-700 rounded px-2 py-1 text-slate-100"
+          />
+        </label>
+        <span class="text-slate-500 hidden md:inline">
+          {{ translate('timeframeHoursHint') }}
+        </span>
+      </div>
     </div>
 
     <PlanetSearch
@@ -182,6 +235,7 @@ function getPlanetById(id: number) {
           :price-resolver="priceResolver"
           :technology-levels="technologyLevels"
           :starting-bonus="startingBonus"
+          :timeframe-hours="timeframeHours"
           :isBaseOpen="(id) => isBaseOpen(id)"
           :getSections="(id) => getSections(id)"
           @toggleBase="

--- a/src/v2/pages/player-config/components/BaseSummaryCard.vue
+++ b/src/v2/pages/player-config/components/BaseSummaryCard.vue
@@ -12,6 +12,7 @@ const props = defineProps<{
   priceResolver: (materialId: number) => number
   technologyLevels: Partial<Record<number, number>>
   startingBonus: number
+  timeframeHours: number
 }>()
 
 const technologyLevelMap = computed(() => {
@@ -63,6 +64,20 @@ const report = computed(() =>
 
 const summary = computed(() => report.value.summary)
 
+const periodFactor = computed(() => {
+  const hours = Number(props.timeframeHours)
+  if (!Number.isFinite(hours)) return 1
+  const clamped = Math.min(336, Math.max(1, Math.round(hours)))
+  return clamped / 24
+})
+
+const summaryForPeriod = computed(() => ({
+  productionRevenue: summary.value.productionRevenue * periodFactor.value,
+  materialPurchaseCosts: summary.value.materialPurchaseCosts * periodFactor.value,
+  workerPurchaseCosts: summary.value.workerPurchaseCosts * periodFactor.value,
+  net: summary.value.net * periodFactor.value,
+}))
+
 function formatNumber(value: number, fractionDigits = 2) {
   return value.toLocaleString(undefined, {
     minimumFractionDigits: 0,
@@ -76,19 +91,21 @@ function formatNumber(value: number, fractionDigits = 2) {
     <div class="text-lg text-slate-300 flex flex-wrap gap-4">
       <div>
         {{ translate('netResult') }}:
-        <span :class="summary.net >= 0 ? 'text-emerald-300' : 'text-rose-300'">{{ formatNumber(summary.net) }}</span>
+        <span :class="summaryForPeriod.net >= 0 ? 'text-emerald-300' : 'text-rose-300'">
+          {{ formatNumber(summaryForPeriod.net) }}
+        </span>
       </div>
       <div>
         {{ translate('workerPurchaseCosts') }}:
-        <span class="text-rose-300">{{ formatNumber(summary.workerPurchaseCosts) }}</span>
+        <span class="text-rose-300">{{ formatNumber(summaryForPeriod.workerPurchaseCosts) }}</span>
       </div>
       <div>
         {{ translate('materialPurchaseCosts') }}:
-        <span class="text-rose-300">{{ formatNumber(summary.materialPurchaseCosts) }}</span>
+        <span class="text-rose-300">{{ formatNumber(summaryForPeriod.materialPurchaseCosts) }}</span>
       </div>
       <div>
         {{ translate('productionRevenue') }}:
-        <span class="text-emerald-300">{{ formatNumber(summary.productionRevenue) }}</span>
+        <span class="text-emerald-300">{{ formatNumber(summaryForPeriod.productionRevenue) }}</span>
       </div>
     </div>
   </div>

--- a/src/v2/pages/player-config/components/ConfiguredBase.vue
+++ b/src/v2/pages/player-config/components/ConfiguredBase.vue
@@ -18,6 +18,7 @@ const props = defineProps<{
   priceResolver: (materialId: number) => number
   technologyLevels: Partial<Record<number, number>>
   startingBonus: number
+  timeframeHours: number
   isBaseOpen: (id: string) => boolean
   getSections: (id: string) => { buildings: boolean; production: boolean; dailySummary: boolean }
 }>()
@@ -208,7 +209,7 @@ function onKey(e: KeyboardEvent) {
       "
     >
       <summary class="px-3 py-2 cursor-pointer font-medium">
-        {{ translate('dailySummary') }}
+        {{ translate('summaryForHours', { hours: props.timeframeHours }) }}
 <!--        <div class="mt-2 space-y-2 px-3">-->
           <BaseSummaryCard
             :base="base"
@@ -217,6 +218,7 @@ function onKey(e: KeyboardEvent) {
             :price-resolver="props.priceResolver"
             :technology-levels="props.technologyLevels"
             :starting-bonus="props.startingBonus"
+            :timeframe-hours="props.timeframeHours"
           />
 <!--        </div>-->
       </summary>
@@ -228,6 +230,7 @@ function onKey(e: KeyboardEvent) {
           :price-resolver="props.priceResolver"
           :technology-levels="props.technologyLevels"
           :starting-bonus="props.startingBonus"
+          :timeframe-hours="props.timeframeHours"
           @updateOptional="
             (materialIds) => {
               $emit('setOptionalConsumables', materialIds)
@@ -266,6 +269,7 @@ function onKey(e: KeyboardEvent) {
           :price-resolver="props.priceResolver"
           :technology-levels="props.technologyLevels"
           :starting-bonus="props.startingBonus"
+          :timeframe-hours="props.timeframeHours"
           @addRecipe="
             (payload) => {
               $emit('addRecipe', payload)

--- a/src/v2/pages/player-config/components/DailyCalculationsSection.vue
+++ b/src/v2/pages/player-config/components/DailyCalculationsSection.vue
@@ -13,6 +13,7 @@ const props = defineProps<{
   priceResolver: (materialId: number) => number
   technologyLevels: Partial<Record<number, number>>
   startingBonus: number
+  timeframeHours: number
 }>()
 
 const emit = defineEmits<{
@@ -24,6 +25,16 @@ const optionalActive = ref<Set<number>>(new Set())
 const stockImportText = ref('')
 const stockImportStatus = ref<{ kind: 'success' | 'error'; message: string } | null>(null)
 let stockImportTimeout: ReturnType<typeof setTimeout> | null = null
+
+const timeframeHours = computed(() => {
+  const hours = Number(props.timeframeHours)
+  if (!Number.isFinite(hours)) return 24
+  return Math.min(336, Math.max(1, Math.round(hours)))
+})
+
+const periodFactor = computed(() => timeframeHours.value / 24)
+
+const periodLabel = computed(() => translate('perHours', { hours: timeframeHours.value }))
 
 const technologyLevelMap = computed(() => {
   const map = new Map<number, number>()
@@ -83,7 +94,10 @@ const materialRows = computed(() =>
   report.value.materials.map((row) => {
     const stock = stockByMaterialId.value.get(row.materialId) ?? 0
     const daysCoverage = row.balancePerDay < 0 ? (stock > 0 ? stock / -row.balancePerDay : 0) : null
-    return { ...row, stock, daysCoverage }
+    const balancePerPeriod = row.balancePerDay * periodFactor.value
+    const valuePerPeriod = row.valuePerDay * periodFactor.value
+    const toBuy = row.balancePerDay < 0 ? -balancePerPeriod : 0
+    return { ...row, stock, daysCoverage, balancePerPeriod, valuePerPeriod, toBuy }
   }),
 )
 
@@ -99,7 +113,17 @@ const workerRows = computed(() => {
 
 const workforceSummary = computed(() => report.value.workforceSummary)
 
-const totalWorkerCosts = computed(() => workerRows.value.reduce((acc, row) => acc + row.costPerDay, 0))
+const workerDisplayRows = computed(() =>
+  workerRows.value.map((row) => ({
+    ...row,
+    consumptionPerPeriod: row.consumptionPerDay * periodFactor.value,
+    costPerPeriod: row.costPerDay * periodFactor.value,
+  })),
+)
+
+const totalWorkerCosts = computed(() =>
+  workerDisplayRows.value.reduce((acc, row) => acc + row.costPerPeriod, 0),
+)
 
 const optionalConsumables = computed(() => {
   const groups: Array<{ tier: 1 | 2 | 3 | 4; options: Array<{ materialId: number; amount: number }> }> = []
@@ -258,7 +282,7 @@ onBeforeUnmount(() => {
 </script>
 
 <template>
-  <div class="space-y-4">
+  <div class="grid gap-4 lg:grid-cols-2">
     <div class="rounded border border-slate-700 bg-slate-900 p-4 space-y-2">
       <div class="font-semibold">{{ translate('stockImportTitle') }}</div>
       <p class="text-xs text-slate-400">{{ translate('stockImportDescription') }}</p>
@@ -329,20 +353,20 @@ onBeforeUnmount(() => {
           </div>
         </div>
       </div>
-      <template v-if="workerRows.length">
+      <template v-if="workerDisplayRows.length">
         <table class="w-full text-sm">
           <thead class="text-slate-400 text-xs uppercase">
             <tr>
               <th class="text-left pb-1">Tier</th>
               <th class="text-left pb-1">{{ translate('material') }}</th>
-              <th class="text-right pb-1">{{ translate('perDay') }}</th>
+              <th class="text-right pb-1">{{ periodLabel }}</th>
               <th class="text-right pb-1">{{ translate('unitPrice') }}</th>
               <th class="text-right pb-1">{{ translate('totalCosts') }}</th>
             </tr>
           </thead>
           <tbody>
             <tr
-              v-for="row in workerRows"
+              v-for="row in workerDisplayRows"
               :key="row.tier + '-' + row.materialId"
               class="border-t border-slate-800/60"
               :class="{ 'opacity-60': row.optional && !row.active }"
@@ -358,9 +382,9 @@ onBeforeUnmount(() => {
                   {{ row.active ? translate('optionalActive') : translate('optionalInactive') }}
                 </span>
               </td>
-              <td class="py-1 text-right">{{ formatNumber(row.consumptionPerDay) }}</td>
+              <td class="py-1 text-right">{{ formatNumber(row.consumptionPerPeriod) }}</td>
               <td class="py-1 text-right">{{ formatNumber(row.unitPrice, 2) }}</td>
-              <td class="py-1 text-right">{{ formatNumber(row.costPerDay) }}</td>
+              <td class="py-1 text-right">{{ formatNumber(row.costPerPeriod) }}</td>
             </tr>
           </tbody>
         </table>
@@ -379,8 +403,9 @@ onBeforeUnmount(() => {
           <thead class="text-slate-400 text-xs uppercase">
             <tr>
               <th class="text-left pb-1">{{ translate('material') }}</th>
-              <th class="text-right pb-1">{{ translate('perDay') }}</th>
+              <th class="text-right pb-1">{{ periodLabel }}</th>
               <th class="text-right pb-1">{{ translate('unitPrice') }}</th>
+              <th class="text-right pb-1">{{ translate('toBuy') }}</th>
               <th class="text-right pb-1">{{ translate('stockCoverage') }}</th>
               <th class="text-right pb-1">{{ translate('netResult') }}</th>
             </tr>
@@ -392,13 +417,16 @@ onBeforeUnmount(() => {
                 class="py-1 text-right"
                 :class="row.balancePerDay >= 0 ? 'text-emerald-300' : 'text-rose-300'"
               >
-                {{ formatNumber(row.balancePerDay) }}
+                {{ formatNumber(row.balancePerPeriod) }}
               </td>
               <td class="py-1 text-right">{{ formatNumber(row.unitPrice, 2) }}</td>
               <td class="py-1 text-right">
+                {{ row.toBuy > 0 ? formatNumber(row.toBuy) : '—' }}
+              </td>
+              <td class="py-1 text-right">
                 {{ row.balancePerDay < 0 ? formatCoverage(row.daysCoverage ?? null) : '—' }}
               </td>
-              <td class="py-1 text-right">{{ formatNumber(row.valuePerDay) }}</td>
+              <td class="py-1 text-right">{{ formatNumber(row.valuePerPeriod) }}</td>
             </tr>
           </tbody>
         </table>

--- a/src/v2/pages/player-config/components/ProductionSection.vue
+++ b/src/v2/pages/player-config/components/ProductionSection.vue
@@ -17,6 +17,7 @@ const props = defineProps<{
   priceResolver: (materialId: number) => number
   technologyLevels: Partial<Record<number, number>>
   startingBonus: number
+  timeframeHours: number
 }>()
 
 const emit = defineEmits<{
@@ -67,6 +68,20 @@ const assignment = computed(() => ({
     recipeId: r.recipeId,
   })),
 }))
+
+const timeframeHours = computed(() => {
+  const hours = Number(props.timeframeHours)
+  if (!Number.isFinite(hours)) return 24
+  return Math.min(336, Math.max(1, Math.round(hours)))
+})
+
+const inputsPerHoursLabel = computed(() =>
+  translate('inputsPerHours', { hours: timeframeHours.value }),
+)
+
+const runsPerHoursLabel = computed(() =>
+  translate('runsPerHours', { hours: timeframeHours.value }),
+)
 
 const report = computed(() =>
   computeBaseReport(props.gameData, {
@@ -170,6 +185,12 @@ const suggestions = computed(() => {
         : availabilityBlocked
           ? availability.reason
           : null
+      const minutesPerPeriod = timeframeHours.value * 60
+      const runsPerPeriod =
+        recipe.timeMinutes > 0
+          ? Math.max(0, minutesPerPeriod / recipe.timeMinutes) * Math.max(units, 0)
+          : 0
+      const outputAmount = recipe.output.amount * runsPerPeriod
       return {
         recipe,
         buildingName: building?.name ?? `#${recipe.producedInId}`,
@@ -184,12 +205,13 @@ const suggestions = computed(() => {
         technologySatisfied,
         inputs: recipe.inputs.map((i) => ({
           name: props.index.materialById.get(i.id)?.name ?? `#${i.id}`,
-          amount: i.amount,
+          amount: i.amount * runsPerPeriod,
         })),
         output: {
           name: props.index.materialById.get(recipe.output.id)?.name ?? recipe.output.name,
-          amount: recipe.output.amount,
+          amount: outputAmount,
         },
+        runsPerPeriod,
         timeMinutes: recipe.timeMinutes,
         workers: workerNeeds
           ? `${workerNeeds.worker}/${workerNeeds.technician}/${workerNeeds.engineer}/${workerNeeds.scientist}`
@@ -267,7 +289,7 @@ watch(
           >
             <div class="flex items-center gap-2">
               <div class="font-medium truncate">
-                {{ item.output.amount }} × {{ item.output.name }}
+                {{ formatNumber(item.output.amount) }} × {{ item.output.name }}
               </div>
               <span class="text-xs text-slate-400">→ {{ item.buildingName }}</span>
               <span v-if="item.alreadySelected" class="text-xs text-amber-300">
@@ -275,14 +297,19 @@ watch(
               </span>
             </div>
             <div class="text-xs text-slate-400 flex flex-wrap gap-1">
-              <span>{{ translate('inputsPerDay') }}:</span>
+              <span>{{ inputsPerHoursLabel }}:</span>
               <span class="text-slate-300">
                 {{
                   item.inputs.length
-                    ? item.inputs.map((i) => `${i.amount} × ${i.name}`).join(', ')
+                    ? item.inputs
+                        .map((i) => `${formatNumber(i.amount)} × ${i.name}`)
+                        .join(', ')
                     : '—'
                 }}
               </span>
+            </div>
+            <div class="text-xs text-slate-500">
+              {{ runsPerHoursLabel }}: {{ formatNumber(item.runsPerPeriod) }}
             </div>
             <div class="text-xs text-slate-500">
               {{ translate('cycleTime') }}: {{ item.timeMinutes }} {{ translate('minutes') }} •
@@ -340,6 +367,7 @@ watch(
               :technology-level="cardsById.get(element.id)!.technologyLevel"
               :required-tech="cardsById.get(element.id)!.requiredTech"
               :material-lookup="props.index.materialById"
+              :timeframe-hours="props.timeframeHours"
               @remove="removeRecipe(element.id)"
             />
           </div>

--- a/src/v2/pages/player-config/components/RecipeTile.vue
+++ b/src/v2/pages/player-config/components/RecipeTile.vue
@@ -12,11 +12,20 @@ const props = defineProps<{
   materialLookup: Map<number, { name: string }>
   technologyLevel: number
   requiredTech: number
+  timeframeHours: number
 }>()
 
 const emit = defineEmits<{ remove: [] }>()
 
 const minutesPerDay = 60 * 24
+
+const displayHours = computed(() => {
+  const hours = Number(props.timeframeHours)
+  if (!Number.isFinite(hours)) return 24
+  return Math.min(336, Math.max(1, Math.round(hours)))
+})
+
+const periodFactor = computed(() => displayHours.value / 24)
 
 const activeUnits = computed(() => props.reportRow?.buildingUnits ?? props.units)
 const queueShare = computed(() => props.reportRow?.queueShare ?? 1)
@@ -27,11 +36,13 @@ const adjustedCycleMinutes = computed(
 const actualCycleMinutes = computed(
   () => props.reportRow?.actualTimeMinutes ?? adjustedCycleMinutes.value,
 )
-const dailyRunsPerModule = computed(() =>
+const runsPerModulePerDay = computed(() =>
   props.reportRow?.cyclesPerDayPerUnit ??
   (props.recipe.timeMinutes > 0 ? minutesPerDay / props.recipe.timeMinutes : 0),
 )
-const runsPerDay = computed(() => props.reportRow?.runsPerDay ?? dailyRunsPerModule.value * activeUnits.value)
+const runsPerDay = computed(
+  () => props.reportRow?.runsPerDay ?? runsPerModulePerDay.value * activeUnits.value,
+)
 
 const outputPerDay = computed(() => {
   if (props.reportRow) return props.reportRow.outputPerDay
@@ -45,6 +56,17 @@ const inputsPerDay = computed(() => {
     amount: inp.amount * runsPerDay.value,
   }))
 })
+
+const runsPerModulePerPeriod = computed(() => runsPerModulePerDay.value * periodFactor.value)
+
+const outputPerPeriod = computed(() => outputPerDay.value * periodFactor.value)
+
+const inputsPerPeriod = computed(() =>
+  inputsPerDay.value.map((inp) => ({
+    materialId: inp.materialId,
+    amount: inp.amount * periodFactor.value,
+  })),
+)
 
 const workforce = computed(() => props.reportRow?.workforce ?? [])
 const workforceFactor = computed(() => props.reportRow?.workforceFactor ?? 1)
@@ -120,22 +142,25 @@ function tierLabel(tier: number) {
           <div>
             {{ translate('queueTimeShare') }}: {{ formatShare(queueShare * 100) }}
           </div>
-          <div>{{ translate('dailyRunsPerModule') }}: {{ formatNumber(dailyRunsPerModule) }}</div>
+          <div>
+            {{ translate('runsPerHours', { hours: displayHours }) }}:
+            {{ formatNumber(runsPerModulePerPeriod) }}
+          </div>
         </div>
 
         <div class="mt-3 space-y-2 text-sm">
           <div>
-            {{ translate('outputPerDay') }}:
-            <span class="text-emerald-300">{{ formatNumber(outputPerDay) }}</span>
+            {{ translate('outputPerHours', { hours: displayHours }) }}:
+            <span class="text-emerald-300">{{ formatNumber(outputPerPeriod) }}</span>
             × {{ recipe.output.name }}
           </div>
           <div>
-            {{ translate('inputsPerDay') }}:
+            {{ translate('inputsPerHours', { hours: displayHours }) }}:
             <ul class="ml-4 list-disc text-slate-300">
-              <li v-for="input in inputsPerDay" :key="input.materialId">
+              <li v-for="input in inputsPerPeriod" :key="input.materialId">
                 {{ formatNumber(input.amount) }} × {{ materialName(input.materialId) }}
               </li>
-              <li v-if="!inputsPerDay.length" class="text-slate-500">—</li>
+              <li v-if="!inputsPerPeriod.length" class="text-slate-500">—</li>
             </ul>
           </div>
           <div v-if="workforce.length">


### PR DESCRIPTION
## Summary
- add a global timeframe selector that persists to local storage and pass the value through player base panels
- recalculate base summaries, workforce/material tables, and layout to reflect the selected timeframe, including a new “to buy” column
- update recipe suggestions/tiles and localisation entries to show per-hour labels using parameterised translations

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f548ce4388324a8c7de4cbe739083)