### PR TITLE
feat: show stock amount alongside stock coverage

### DIFF
--- a/src/v2/pages/player-config/components/SummaryCalculationsSection.vue
+++ b/src/v2/pages/player-config/components/SummaryCalculationsSection.vue
@@ -357,7 +357,10 @@ onBeforeUnmount(() => {
                 class="py-1 text-right"
                 :class="row.toBuy > 0 ? 'text-rose-300' : 'text-emerald-300'"
               >
-                {{ row.balancePerDay < 0 ? formatCoverage(row.daysCoverage ?? null) : '—' }}
+                <template v-if="row.balancePerDay < 0">
+                  {{ formatNumber(row.stock, 0) }} / {{ formatCoverage(row.daysCoverage ?? null) }}
+                </template>
+                <template v-else>—</template>
               </td>
               <td
                 class="py-1 text-right"


### PR DESCRIPTION
- Display format: 'stock / coverage' (e.g., '150 / 2d 4h')
- Shows current stock amount before coverage time
- Makes it easier to see absolute quantities at a glance

<img width="127" height="195" alt="image" src="https://github.com/user-attachments/assets/7cf80d42-4fb8-4c43-9a78-cd3977195f18" />
